### PR TITLE
Output and display old year charts

### DIFF
--- a/srv/index.js
+++ b/srv/index.js
@@ -12,15 +12,6 @@ import Charts from "./tabs/charts.js";
 import Info from "./tabs/info.js";
 import Table from "./tabs/table.js";
 
-d3.select("body")
-    .append("div")
-    .attr("id", "container")
-    .append("div")
-    .attr("id", "head-container")
-    .append("div")
-    .attr("id", "head")
-    .classed("columns is-multiline is-gapless is-centered", true);
-
 class State {
     constructor() {
         this.autoscroll = true;
@@ -28,26 +19,41 @@ class State {
 }
 
 const locale = new Locale();
-const data = new Data(currentData);
-const format = new Format(data);
 const state = new State();
+const defaultData = new Data(currentData);
 
-const scroll = new Scroll(locale, data, format, state);
-const search = new Search(locale, data, state, scroll);
+const load = (data=defaultData) => {
+    d3.select("#container").remove();
+    d3.select("body")
+        .append("div")
+        .attr("id", "container")
+        .append("div")
+        .attr("id", "head-container")
+        .append("div")
+        .attr("id", "head")
+        .classed("columns is-multiline is-gapless is-centered", true);
 
-const charts = new Charts(locale, data, format);
-const info = new Info(data);
-const table = new Table(locale, data, search, scroll, state);
+    const format = new Format(data);
 
-const tabs = new Tabs(data, scroll, charts);
+    const scroll = new Scroll(locale, data, format, state);
+    const search = new Search(locale, data, state, scroll);
 
-tabs.create();
-scroll.create();
+    const charts = new Charts(locale, data, format);
+    const info = new Info(data);
+    const table = new Table(locale, data, search, scroll, state);
 
-scroll.updatePagination();
-table.create();
-charts.create();
-info.create();
-search.createModal();
+    const tabs = new Tabs(data, scroll, charts);
 
-tabs.enable();
+    tabs.create();
+    scroll.create();
+
+    scroll.updatePagination();
+    table.create();
+    charts.create();
+    info.create();
+    search.createModal();
+
+    return tabs;
+};
+
+load().enable(load);

--- a/srv/search.js
+++ b/srv/search.js
@@ -44,6 +44,7 @@ export default class SearchModal {
     }
 
     createModal = () => {
+        d3.select("#search").remove();
         const modal = d3.select("body").append("div")
             .attr("id", "search")
             .classed("modal", true);

--- a/top2000/__main__.py
+++ b/top2000/__main__.py
@@ -2,14 +2,17 @@
 Parse lists of song tracks in the NPO Radio 2 Top 2000 from various years.
 """
 
-from collections import deque
 import sys
+from collections import deque
+
 from .output.base import Format
 from .readers.base import Base as ReaderBase
-from .readers.multi import Years, OldFiles
+from .readers.multi import OldFiles, Years
 
-def _parse_first_args(argv: deque[str]) \
-        -> tuple[list[str], list[type[ReaderBase]], list[type[Format]], float | None]:
+
+def _parse_first_args(
+    argv: deque[str],
+) -> tuple[list[str], list[type[ReaderBase]], list[type[Format]], float | None]:
     readers: list[type[ReaderBase]] = []
     outputs: list[type[Format]] = []
     latest_year: float | None = None
@@ -45,6 +48,7 @@ def _parse_first_args(argv: deque[str]) \
 
     return list(argv), readers, outputs, latest_year
 
+
 def _sort_year(old_year: float) -> float:
     if int(old_year) == old_year:
         return old_year
@@ -52,36 +56,48 @@ def _sort_year(old_year: float) -> float:
     # handled afterwards.
     return old_year - 1
 
-def _parse_year_args(reader: Years, argv: list[str],
-                     current_year: float) -> tuple[str, str, OldFiles]:
+
+def _parse_year_args(
+    reader: Years, argv: list[str], current_year: float
+) -> tuple[str, str, OldFiles]:
     current_year_csv, current_year_json = reader.format_filenames(*argv[0:2])
     try:
         if len(argv) > 4:
             # Triples of year, CSV filename, JSON filename
-            old: OldFiles = tuple(zip((float(year) for year in argv[2::3]),
-                                      argv[3::3], argv[4::3]))
+            old: OldFiles = tuple(
+                zip((float(year) for year in argv[2::3]), argv[3::3], argv[4::3])
+            )
         elif len(argv) > 2:
             # Single year using formats from arguments or from fields
             csv_name_format = argv[0] if "{}" in argv[0] else None
             json_name_format = argv[1] if "{}" in argv[1] else None
             year = float(argv[2])
-            old = ((year,
-                    *reader.format_filenames(csv_name_format=csv_name_format,
-                                             json_name_format=json_name_format,
-                                             year=year)),)
+            old = (
+                (
+                    year,
+                    *reader.format_filenames(
+                        csv_name_format=csv_name_format,
+                        json_name_format=json_name_format,
+                        year=year,
+                    ),
+                ),
+            )
         else:
-            old_years: set[float] = set(range(int(reader.first_csv_year),
-                                              int(current_year)))
+            old_years: set[float] = set(
+                range(int(reader.first_csv_year), int(current_year))
+            )
             old_years.update(reader.years)
             old_years.discard(current_year)
-            old = tuple((year, *reader.format_filenames(year=year))
-                        for year in sorted(old_years, reverse=True,
-                                           key=_sort_year))
+            old = tuple(
+                (year, *reader.format_filenames(year=year))
+                for year in sorted(old_years, reverse=True, key=_sort_year)
+            )
     except ValueError:
         # One of the first arguments in triples was not a year, skip them all
         old = tuple()
 
     return current_year_csv, current_year_json, old
+
 
 def main(argv: list[str]) -> int:
     """
@@ -91,37 +107,51 @@ def main(argv: list[str]) -> int:
     try:
         argv, inputs, outputs, latest_year = _parse_first_args(deque(argv))
     except ValueError:
-        print('Usage: python -m top2000 [inputs...] [outputs...] [latest_year]',
-              file=sys.stderr)
-        print('                         [current_csv] [current_json]',
-              file=sys.stderr)
-        print('                         [old_year] [old_csv] [old_json] ...',
-              file=sys.stderr)
+        print(
+            "Usage: python -m top2000 [inputs...] [outputs...] [latest_year]",
+            file=sys.stderr,
+        )
+        print("                         [current_csv] [current_json]", file=sys.stderr)
+        print(
+            "                         [old_year] [old_csv] [old_json] ...",
+            file=sys.stderr,
+        )
         return 0
 
-    readers: list[ReaderBase] = []
     current_year = ReaderBase.first_year
-    for inputter in inputs:
-        reader = inputter(year=latest_year)
-        if latest_year is None:
-            current_year = reader.latest_year
-        else:
-            current_year = latest_year
+    years = deque((latest_year,))
+    old_data_available = False
+    while years:
+        year = years.popleft()
 
-        if isinstance(reader, Years):
-            reader.read_files(*_parse_year_args(reader, argv, current_year))
-        else:
-            reader.read()
+        readers: list[ReaderBase] = []
+        for inputter in inputs:
+            reader = inputter(year=year)
+            if latest_year is None:
+                current_year = latest_year = reader.latest_year
+                years.extend(range(ReaderBase.first_year, current_year))
+                old_data_available = True
+            else:
+                current_year = latest_year if year is None else year
+                latest_year = max(latest_year, reader.latest_year)
 
-        readers.append(reader)
+            if isinstance(reader, Years):
+                reader.read_files(*_parse_year_args(reader, argv, current_year))
+            else:
+                reader.read()
 
-    for output in outputs:
-        formatter = output(ReaderBase.first_year, current_year)
-        for output_format in formatter.output_names:
-            if not formatter.output_file(readers, output_format):
-                return 1
+            readers.append(reader)
+
+        for output in outputs:
+            formatter = output(ReaderBase.first_year, current_year, latest_year)
+            for output_format in formatter.output_names:
+                if not formatter.output_file(
+                    readers, output_format, old_data_available=old_data_available
+                ):
+                    return 1
 
     return 0
+
 
 if __name__ == "__main__":
     sys.exit(main(sys.argv[1:]))

--- a/top2000/output/csv.py
+++ b/top2000/output/csv.py
@@ -6,9 +6,21 @@ import csv
 from datetime import datetime
 from pathlib import Path
 from typing import Sequence
+
+from ..readers.base import (
+    Artists,
+    Key,
+    Positions,
+    Tracks,
+)
+from ..readers.base import (
+    Base as ReaderBase,
+)
+from ..readers.base import (
+    Row as Track,
+)
 from .base import Format
-from ..readers.base import Base as ReaderBase, Key, Row as Track, Positions, \
-    Tracks, Artists
+
 
 @Format.register("csv")
 class CSV(Format):
@@ -23,8 +35,13 @@ class CSV(Format):
         self._lines = 0
         self._extra_lines = 0
 
-    def output_file(self, readers: list[ReaderBase], output_format: str,
-                    path: Path | None = None) -> bool:
+    def output_file(
+        self,
+        readers: list[ReaderBase],
+        output_format: str,
+        path: Path | None = None,
+        old_data_available: bool = False,
+    ) -> bool:
         if not readers:
             return False
         if path is None:
@@ -42,24 +59,24 @@ class CSV(Format):
         header = list(column_names.values()) * columns
         self.reset()
         data = readers[0]
-        with path.open("w", encoding='utf-8') as output:
+        with path.open("w", encoding="utf-8") as output:
             writer = csv.writer(output)
             writer.writerow(header)
             for position, keys in self._sort_positions(data.positions, reverse):
-                cells = self._format_cells(position, keys, data.tracks,
-                                           data.artists)
-                if self._format_timestamp(output_format, cells, data.positions,
-                                          position):
+                cells = self._format_cells(position, keys, data.tracks, data.artists)
+                if self._format_timestamp(
+                    output_format, cells, data.positions, position
+                ):
                     writer.writerows(self._rows)
                     self._rows = []
 
                 row = [cells.get(column, "") for column in column_names]
-                #writer.writerow(row)
+                # writer.writerow(row)
 
                 self.validate_row(keys, cells, data.tracks, data.artists)
 
                 if self.add_row(output_format, row, data.positions, position):
-                    #print('WRITE')
+                    # print('WRITE')
                     writer.writerows(self._rows)
                     self._rows = []
                     self._extra_lines = 0
@@ -71,12 +88,12 @@ class CSV(Format):
             if self._rows:
                 writer.writerows(self._rows)
 
-
-        print(f'{self._lines} lines above indicate problems with tracks.')
+        print(f"{self._lines} lines above indicate problems with tracks.")
         return self._lines == 0
 
-    def _format_cells(self, position: int, keys: Sequence[Key],
-                      tracks: Tracks, artists: Artists) -> dict[str, str]:
+    def _format_cells(
+        self, position: int, keys: Sequence[Key], tracks: Tracks, artists: Artists
+    ) -> dict[str, str]:
         key = keys[0]
         track = tracks[key]
         artist = str(track["artiest"])
@@ -89,17 +106,16 @@ class CSV(Format):
             title += " \u29be"
 
         max_artist_key = self._find_artist_chart(position, keys, artists)
-        extra_text += self._format_artist_chart(position,
-                                                max_artist_key, artists)
+        extra_text += self._format_artist_chart(position, max_artist_key, artists)
 
         if "jaar" in track:
-            artist += f' ({track["jaar"]})'
+            artist += f" ({track['jaar']})"
 
         return {
             "position": str(position),
             "artist": artist,
             "title": f"{title} ({extra_text})",
-            "timestamp": str(track.get("timestamp", ""))
+            "timestamp": str(track.get("timestamp", "")),
         }
 
     def _format_rank_change(self, track: Track, position: int) -> str:
@@ -108,80 +124,86 @@ class CSV(Format):
             previous_position = int(track[previous_year])
             diff = abs(position - previous_position)
             if position < previous_position:
-                #return f"\xE2\x86\x91{diff}" # upwards arrow
-                #return f"\u2b06\ufe0e{diff}" # upwards arrow
-                #return f"\u21b0{diff}" # upwards arrow
-                return f"\u219f{diff}" # upwards arrow
+                # return f"\xE2\x86\x91{diff}" # upwards arrow
+                # return f"\u2b06\ufe0e{diff}" # upwards arrow
+                # return f"\u21b0{diff}" # upwards arrow
+                return f"\u219f{diff}"  # upwards arrow
             if position > previous_position:
-                #return f"\xE2\x86\x93{diff}" # downwards arrow
-                #return f"\u2b07\ufe0e{diff}" # downwards arrow
-                #return f"\u21b2{diff}" # downwards arrow
-                return f"\u21a1{diff}" # downwards arrow
+                # return f"\xE2\x86\x93{diff}" # downwards arrow
+                # return f"\u2b07\ufe0e{diff}" # downwards arrow
+                # return f"\u21b2{diff}" # downwards arrow
+                return f"\u21a1{diff}"  # downwards arrow
 
             # Stayed the same
-            return "\u21c4" # left right arrow
-            #return "\U0001f51b" # left right arrow
+            return "\u21c4"  # left right arrow
+            # return "\U0001f51b" # left right arrow
 
         for year in range(self._current_year - 2, self._first_year - 1, -1):
             if str(year) in track and track[str(year)] != "0":
-                #if current_year - year - 1 <= 1:
+                # if current_year - year - 1 <= 1:
                 #    extra_text = "\xE2\x9F\xB3"
                 #    extra_text *= current_year - year - 1
                 #    return extra_text
-                #else:
-                #return f"\u27f2{year}" # rotation
-                #return f"\xE2\x86\xBA{year}" # rotation
-                return f"\u21ba{year}" # rotation
-                #return f"\U0001f504{year}" # arrow circle
+                # else:
+                # return f"\u27f2{year}" # rotation
+                # return f"\xE2\x86\xBA{year}" # rotation
+                return f"\u21ba{year}"  # rotation
+                # return f"\U0001f504{year}" # arrow circle
 
-        return "\u2234" # therefore sign
-        #return "\U0001f195" # new sign
+        return "\u2234"  # therefore sign
+        # return "\U0001f195" # new sign
 
     @staticmethod
-    def _format_artist_chart(position: int, max_artist_key: str | None,
-                             artists: Artists) -> str:
+    def _format_artist_chart(
+        position: int, max_artist_key: str | None, artists: Artists
+    ) -> str:
         if max_artist_key in artists:
             artist_tracks = artists[max_artist_key]
-            #print(max_artist_key, artist_tracks)
+            # print(max_artist_key, artist_tracks)
             artist_pos = artist_tracks.index(position) + 1
-            #if len(artist_tracks) == artist_pos:
+            # if len(artist_tracks) == artist_pos:
             #    extra_text += f" {artist_pos}"
-            #else:
+            # else:
             return f" {artist_pos}/{len(artist_tracks)}"
         return ""
 
-    def _format_timestamp(self, output_format: str, cells: dict[str, str],
-                          positions: Positions, position: int) -> bool:
-        #if 'timestamp' in track:
+    def _format_timestamp(
+        self,
+        output_format: str,
+        cells: dict[str, str],
+        positions: Positions,
+        position: int,
+    ) -> bool:
+        # if 'timestamp' in track:
         #    parts = track['timestamp'].split(' ')
         #    time += f"{parts[0]}/12"
         #    time += f" {int(parts[2].split('-')[0]):02}:00"
         #    artist += time
-        if 'timestamp' in cells:
-            if cells['timestamp'].isnumeric():
-                date = datetime.fromtimestamp(int(cells['timestamp']) / 1000)
+        if "timestamp" in cells:
+            if cells["timestamp"].isnumeric():
+                date = datetime.fromtimestamp(int(cells["timestamp"]) / 1000)
                 cells["timestamp"] = datetime.strftime(date, "%d.%H:%M")
                 return False
             if self._last_timestamp is not None:
-                parts = cells['timestamp'].split(' ')
+                parts = cells["timestamp"].split(" ")
                 time = f" {parts[0]}/12 {int(parts[2].split('-')[0]):02}:00"
-                cells.pop('timestamp')
+                cells.pop("timestamp")
                 if time != self._last_timestamp:
                     self._last_timestamp = time
-                    if self.add_row(output_format, ['', time, ''],
-                                    positions, position):
+                    if self.add_row(output_format, ["", time, ""], positions, position):
                         self._extra_lines = 0
                         return True
 
                     self._extra_lines += 1
                     return False
-            #print(track)
-        #else:
+            # print(track)
+        # else:
         #    print(track)
         return False
 
-    def validate_row(self, keys: list[Key], cells: dict[str, str],
-                     tracks: Tracks, artists: Artists) -> None:
+    def validate_row(
+        self, keys: list[Key], cells: dict[str, str], tracks: Tracks, artists: Artists
+    ) -> None:
         """
         Validate whether a track to be output is actually proper.
         """
@@ -189,38 +211,39 @@ class CSV(Format):
 
         # Start debug lines
 
-        #line = f'{cells["position"]}. {cells["artist"]} - {cells["title"]}'
-        #prv_field = "prv"
-        #position = int(cells["position"])
+        # line = f'{cells["position"]}. {cells["artist"]} - {cells["title"]}'
+        # prv_field = "prv"
+        # position = int(cells["position"])
 
-        #previous_year = str(self._current_year - 1)
-        #track = tracks[keys[0]]
-        #artist = track["artiest"]
-        #title = track["titel"]
-        #max_artist_key = self._find_artist_chart(position, keys, artists)
+        # previous_year = str(self._current_year - 1)
+        # track = tracks[keys[0]]
+        # artist = track["artiest"]
+        # title = track["titel"]
+        # max_artist_key = self._find_artist_chart(position, keys, artists)
         # SONGS THAT WERE RELEASED BEFORE THIS YEAR BUT ARE NEW
-        #first_csv_year = 2014
-        #if all(str(year) not in track for year in range(first_csv_year, self._current_year)) and ("jaar" not in track or track["jaar"] != str(self._current_year)):# and position > 1337:
+        # first_csv_year = 2014
+        # if all(str(year) not in track for year in range(first_csv_year, self._current_year)) and ("jaar" not in track or track["jaar"] != str(self._current_year)):# and position > 1337:
         # OLD VERSIONS OF THE FORMER
-        #if "2018" not in track and "2017" not in track and "2016" not in track and "2015" not in track and "2014" not in track and ("yr" not in track or track["yr"] != str(self._current_year)): #and position > 1773:
-        #if "2018" not in track and ("2017" in track or "2016" in track or "2015" in track) and ("jaar" not in track or track["jaar"] != str(self._current_year)): #and position > 1773:
-        #if "2019" not in track and ("2018" in track or "2017" in track or "2016" in track or "2015" in track) and ("jaar" not in track or track["jaar"] != str(self._current_year)): #and position > 1773:
+        # if "2018" not in track and "2017" not in track and "2016" not in track and "2015" not in track and "2014" not in track and ("yr" not in track or track["yr"] != str(self._current_year)): #and position > 1773:
+        # if "2018" not in track and ("2017" in track or "2016" in track or "2015" in track) and ("jaar" not in track or track["jaar"] != str(self._current_year)): #and position > 1773:
+        # if "2019" not in track and ("2018" in track or "2017" in track or "2016" in track or "2015" in track) and ("jaar" not in track or track["jaar"] != str(self._current_year)): #and position > 1773:
         # MISSING YEARS
-        #if 'yr' not in track and 'jaar' not in track:
+        # if 'yr' not in track and 'jaar' not in track:
         # UPPERCASE ARTISTS/TITLES (sometimes happens with new tracks?)
-        #if (artist.isupper() or title.isupper() or artist.islower() or title.islower()) and (title.isupper() or track["artiest"] not in ("U2", "10cc", "INXS", "KISS", "Q65", "LP", "ABBA", "MGMT", "R.E.M.", "UB40", "3JS", "BAP", "AC/DC", "S10")):
-            #pass
+        # if (artist.isupper() or title.isupper() or artist.islower() or title.islower()) and (title.isupper() or track["artiest"] not in ("U2", "10cc", "INXS", "KISS", "Q65", "LP", "ABBA", "MGMT", "R.E.M.", "UB40", "3JS", "BAP", "AC/DC", "S10")):
+        # pass
         # INCONSISTENT PREVIOUS YEAR FIELDS (missing/wrong merges/etc)
-        #if (prv_field in track and int(track[prv_field]) != int(track.get(previous_year, 0))) and int(track.get(previous_year, 0)) <= 2000:
-        #if max_artist_key not in artists or (len(artists[max_artist_key]) == 1 and artist.count(' ') > 2):
-            #self._lines += 1
-            #print(line)
-            #print(track)
-            #print(keys)
-            #print(f"{line} prv={track[prv_field]} {previous_year}={track.get(previous_year)}")
+        # if (prv_field in track and int(track[prv_field]) != int(track.get(previous_year, 0))) and int(track.get(previous_year, 0)) <= 2000:
+        # if max_artist_key not in artists or (len(artists[max_artist_key]) == 1 and artist.count(' ') > 2):
+        # self._lines += 1
+        # print(line)
+        # print(track)
+        # print(keys)
+        # print(f"{line} prv={track[prv_field]} {previous_year}={track.get(previous_year)}")
 
-    def add_row(self, output_format: str, row: list[str], positions: Positions,
-                position: int) -> bool:
+    def add_row(
+        self, output_format: str, row: list[str], positions: Positions, position: int
+    ) -> bool:
         """
         Insert a row in the proper location of a page of a CSV spreadsheet if it
         were printed in certain column counts and rows per page.
@@ -236,8 +259,11 @@ class CSV(Format):
         else:
             page_position = (position + self._extra_lines) % rows_total
 
-        if columns > 1 and self._last_position is not None and \
-                (page_position == 0 or page_position > rows):
+        if (
+            columns > 1
+            and self._last_position is not None
+            and (page_position == 0 or page_position > rows)
+        ):
             if reverse:
                 last_row = (len(positions) - self._last_position + 1) % rows
             else:

--- a/top2000/output/json.py
+++ b/top2000/output/json.py
@@ -2,14 +2,16 @@
 JSON dump output.
 """
 
-from itertools import zip_longest
 import json
+from itertools import zip_longest
 from pathlib import Path
+
+from ..readers.base import Artists, ExtraData, Key, Row, RowElement
+from ..readers.base import Base as ReaderBase
 from .base import Format, KeyPair
-from ..readers.base import Base as ReaderBase, Key, Row, RowElement, Artists, \
-    ExtraData
 
 FieldMap = dict[str, str]
+
 
 @Format.register("json")
 class JSON(Format):
@@ -17,12 +19,22 @@ class JSON(Format):
     JSON file with all details.
     """
 
-    def output_file(self, readers: list[ReaderBase], output_format: str,
-                    path: Path | None = None) -> bool:
+    def output_file(
+        self,
+        readers: list[ReaderBase],
+        output_format: str,
+        path: Path | None = None,
+        old_data_available: bool = False,
+    ) -> bool:
         if not readers:
             return False
         if path is None:
-            path = Path(f"output-{output_format}.json")
+            name = (
+                output_format
+                if self._current_year == self._latest_year
+                else self._current_year
+            )
+            path = Path(f"output-{name}.json")
 
         reverse = self._get_bool_setting(output_format, "reverse")
         relevant = self._get_bool_setting(output_format, "relevant")
@@ -33,15 +45,17 @@ class JSON(Format):
         track_keys: list[list[Key]] = []
         tracks = []
         positions: list[int] = []
-        reader_fields, numeric_fields = self._build_fields(readers,
-                                                           output_format)
+        reader_fields, numeric_fields = self._build_fields(readers, output_format)
 
-        for reader_keys in zip_longest(*(self._sort_positions(reader.positions,
-                                                              reverse)
-                                         for reader in readers)):
+        for reader_keys in zip_longest(
+            *(self._sort_positions(reader.positions, reverse) for reader in readers)
+        ):
             self._check_positions(reader_keys, reverse)
-            tracks.append(self._aggregate_track(readers, reader_keys,
-                                                reader_fields, numeric_fields))
+            tracks.append(
+                self._aggregate_track(
+                    readers, reader_keys, reader_fields, numeric_fields
+                )
+            )
             if reader_keys[0] is not None:
                 positions.append(reader_keys[0][0])
 
@@ -54,29 +68,35 @@ class JSON(Format):
             "artists": self._select_artists(readers, track_keys, relevant),
             "first_year": self._first_year,
             "year": self._current_year,
+            "latest_year": self._latest_year,
+            "old_data_available": old_data_available,
             "reverse": reverse,
-            "columns": self._get_dict_setting(output_format, "columns")
+            "columns": self._get_dict_setting(output_format, "columns"),
         }
         data.update(self._select_extra_data(readers))
 
         with path.open("w", encoding="utf-8") as json_file:
-            json.dump(data, json_file, separators=(',', ':'))
+            json.dump(data, json_file, separators=(",", ":"))
 
         return True
 
     def _sort_readers(self, readers: list[ReaderBase]) -> None:
         try:
             # First first reader without its own input format
-            primary = next(index for index, reader in enumerate(readers)
-                           if reader.input_format is None)
+            primary = next(
+                index
+                for index, reader in enumerate(readers)
+                if reader.input_format is None
+            )
             readers[0], readers[primary] = readers[primary], readers[0]
         except StopIteration:
             # Assume first reader is primary and use it twice for aggregation
             # into main track and subtracks
             readers.insert(0, readers[0])
 
-    def _check_positions(self, reader_keys: tuple[KeyPair | None, ...],
-                         reverse: bool) -> None:
+    def _check_positions(
+        self, reader_keys: tuple[KeyPair | None, ...], reverse: bool
+    ) -> None:
         last_position = self._last_position
         next_position: int | None = None
         for pair in reader_keys:
@@ -87,28 +107,37 @@ class JSON(Format):
 
         self._last_position = next_position
 
-    def _build_fields(self, readers: list[ReaderBase],
-                      output_format: str) -> tuple[list[FieldMap], set[str]]:
-        reader_fields = [self._get_dict_setting(output_format,
-                                                "fields" if index == 0 or
-                                                reader.input_format is None
-                                                else reader.input_format)
-                         for index, reader in enumerate(readers)]
-        reader_fields[0].update({
-            str(year): str(year)
-            for year in range(self._first_year, self._current_year)
-        })
+    def _build_fields(
+        self, readers: list[ReaderBase], output_format: str
+    ) -> tuple[list[FieldMap], set[str]]:
+        reader_fields = [
+            self._get_dict_setting(
+                output_format,
+                "fields"
+                if index == 0 or reader.input_format is None
+                else reader.input_format,
+            )
+            for index, reader in enumerate(readers)
+        ]
+        reader_fields[0].update(
+            {
+                str(year): str(year)
+                for year in range(self._first_year, self._current_year)
+            }
+        )
         numeric_fields = {"year"}
-        numeric_fields.update({
-            str(year) for year in range(self._first_year, self._current_year)
-        })
+        numeric_fields.update(
+            {str(year) for year in range(self._first_year, self._current_year)}
+        )
         return reader_fields, numeric_fields
 
-    def _aggregate_track(self, readers: list[ReaderBase],
-                         reader_keys: tuple[KeyPair | None, ...],
-                         reader_fields: list[FieldMap],
-                         numeric_fields: set[str]) \
-            -> dict[str, RowElement | Row]:
+    def _aggregate_track(
+        self,
+        readers: list[ReaderBase],
+        reader_keys: tuple[KeyPair | None, ...],
+        reader_fields: list[FieldMap],
+        numeric_fields: set[str],
+    ) -> dict[str, RowElement | Row]:
         track: dict[str, RowElement | Row] = {}
         primary = True
         for reader, pair, fields in zip(readers, reader_keys, reader_fields):
@@ -116,12 +145,10 @@ class JSON(Format):
                 continue
 
             position, keys = pair
-            subtrack = self._filter_track(reader, keys, fields,
-                                          numeric_fields)
+            subtrack = self._filter_track(reader, keys, fields, numeric_fields)
             if primary:
                 track.update(subtrack)
-                max_artist_key = self._find_artist_chart(position, keys,
-                                                         reader.artists)
+                max_artist_key = self._find_artist_chart(position, keys, reader.artists)
                 if max_artist_key is not None:
                     track["max_artist_key"] = max_artist_key
             elif reader.input_format is not None:
@@ -132,13 +159,11 @@ class JSON(Format):
         return track
 
     @staticmethod
-    def _filter_track(reader: ReaderBase, keys: list[Key],
-                      fields: FieldMap, numeric_fields: set[str]) -> Row:
+    def _filter_track(
+        reader: ReaderBase, keys: list[Key], fields: FieldMap, numeric_fields: set[str]
+    ) -> Row:
         track = reader.tracks[keys[0]]
-        track = {
-            field: track[key] for key, field in fields.items()
-            if key in track
-        }
+        track = {field: track[key] for key, field in fields.items() if key in track}
         for field in numeric_fields:
             if field in track:
                 if track[field] in {"", "0", 0}:
@@ -148,9 +173,12 @@ class JSON(Format):
 
         return track
 
-    def _select_keys(self, readers: list[ReaderBase],
-                     reader_keys: tuple[KeyPair | None, ...],
-                     relevant: bool = False) -> list[Key]:
+    def _select_keys(
+        self,
+        readers: list[ReaderBase],
+        reader_keys: tuple[KeyPair | None, ...],
+        relevant: bool = False,
+    ) -> list[Key]:
         if not relevant:
             return reader_keys[0][1] if reader_keys[0] is not None else []
         relevant_keys: dict[tuple[int, ...], Key] = {}
@@ -159,16 +187,20 @@ class JSON(Format):
             if reader is readers[0] and not primary:
                 continue
             if key_pair is not None:
-                reader.select_relevant_keys(relevant_keys, key_pair[0],
-                                            key_pair[1], primary=readers[0])
+                reader.select_relevant_keys(
+                    relevant_keys, key_pair[0], key_pair[1], primary=readers[0]
+                )
             primary = False
-        #if "bob marley" in list(relevant_keys.values())[0][0]:
+        # if "bob marley" in list(relevant_keys.values())[0][0]:
         #    print(reader_keys, relevant_keys)
         return list(relevant_keys.values())
 
-    def _select_artists(self, readers: list[ReaderBase],
-                        track_keys: list[list[Key]],
-                        relevant: bool = False) -> Artists:
+    def _select_artists(
+        self,
+        readers: list[ReaderBase],
+        track_keys: list[list[Key]],
+        relevant: bool = False,
+    ) -> Artists:
         artists: Artists = {}
         relevant_keys: set[str] = set()
         if relevant:
@@ -178,13 +210,16 @@ class JSON(Format):
             if not relevant:
                 artists.update(reader.artists)
             else:
-                artists.update({artist: chart
-                                for artist, chart in reader.artists.items()
-                                if artist in relevant_keys})
+                artists.update(
+                    {
+                        artist: chart
+                        for artist, chart in reader.artists.items()
+                        if artist in relevant_keys
+                    }
+                )
         return artists
 
-    def _select_extra_data(self,
-                           readers: list[ReaderBase]) -> dict[str, ExtraData]:
+    def _select_extra_data(self, readers: list[ReaderBase]) -> dict[str, ExtraData]:
         primary = True
         data: dict[str, ExtraData] = {}
         credits_data: list[Row] = []

--- a/top2000/readers/wiki.py
+++ b/top2000/readers/wiki.py
@@ -197,14 +197,14 @@ class Wiki(Base):
         if title_links := links.get(fields["title"], {}):
             self._tracks[best_key]["title_link"] = title_links.popitem()[0]
 
-        if position != len(self._artist_links) + 1:
-            raise ValueError(f"{position} != {len(self._artist_links) + 1}")
+        while position > len(self._artist_links):
+            self._artist_links.append({})
 
         artist_links: Row = {}
         normalizer = Normalizer.get_instance()
         for link, artist in links.get(fields["artist"], {}).items():
             artist_links[link] = normalizer.find_artist_alternatives(artist)[-1]
-        self._artist_links.append(artist_links)
+        self._artist_links[position - 1] = artist_links
 
     @property
     def extra_data(self) -> dict[str, ExtraData]:


### PR DESCRIPTION
Closes #11 although further improvements are possible:

- Instead of running all readers and output formatters for each year, provide multi-year output from each reader and formatter
- Instead of deleting all containers and recreating the view when tab changes, use some better data joins and transformations
- Sharing dump output (to reduce sizes of charts) 
- Make the search go through all the years if a song does not exist in the current year, or some selection options
- Chart analysis with multiple years
