### PR TITLE
Reuse reader for multiple year data

### DIFF
--- a/fixes.toml
+++ b/fixes.toml
@@ -382,6 +382,7 @@ type = "mapping"
 # Some could be moved to artist_replaces
 type = "mapping"
 [artist_full_replaces.items]
+"ZZ & de Maskers" = "ZZ en de Maskers"
 "One Republic" = "OneRepublic"
 "Blue Oyster Cult" = "Blue \u00d6yster Cult"
 "PHD" = "Ph.D."

--- a/top2000/output/json.py
+++ b/top2000/output/json.py
@@ -127,7 +127,7 @@ class JSON(Format):
         )
         numeric_fields = {"year"}
         numeric_fields.update(
-            {str(year) for year in range(self._first_year, self._current_year)}
+            {str(year) for year in range(self._first_year, self._latest_year)}
         )
         return reader_fields, numeric_fields
 
@@ -163,6 +163,9 @@ class JSON(Format):
         reader: ReaderBase, keys: list[Key], fields: FieldMap, numeric_fields: set[str]
     ) -> Row:
         track = reader.tracks[keys[0]]
+        # if track.get("title_link") == "Master Blaster (Jammin')":
+        #    print(track)
+        #    print(fields)
         track = {field: track[key] for key, field in fields.items() if key in track}
         for field in numeric_fields:
             if field in track:

--- a/top2000/readers/csv.py
+++ b/top2000/readers/csv.py
@@ -4,7 +4,9 @@ NPO Radio 2 Top 2000 CSV reader.
 
 import csv
 from pathlib import Path
-from .base import Base, Positions, Tracks, Artists, Row, Key, FieldMap
+
+from .base import Artists, Base, FieldMap, Key, Positions, Row, Tracks
+
 
 class CSV(Base):
     """
@@ -20,9 +22,13 @@ class CSV(Base):
         csv_path = Path(csv_name_format.format(int(self._year)))
         self.read_file(csv_path)
 
-    def read_file(self, csv_path: Path, positions: Positions | None = None,
-                  tracks: Tracks | None = None,
-                  artists: Artists | None = None) -> None:
+    def read_file(
+        self,
+        csv_path: Path,
+        positions: Positions | None = None,
+        tracks: Tracks | None = None,
+        artists: Artists | None = None,
+    ) -> None:
         """
         Read a CSV file with track position data.
         """
@@ -40,21 +46,22 @@ class CSV(Base):
             "pos": self._get_str_field("pos", "positie"),
             "artist": self._get_str_field("artist", "artiest"),
             "title": self._get_str_field("title", "titel"),
-            "year": self._get_str_field("year", "jaar")
+            "year": self._get_str_field("year", "jaar"),
         }
         offset = self._get_int_field("offset", 0)
-        with csv_path.open('r', encoding=encoding) as csv_file:
+        with csv_path.open("r", encoding=encoding) as csv_file:
             reader = csv.DictReader(csv_file)
             for row in reader:
                 self._read_row(row, fields, offset=offset)
 
-    def _read_row(self, row: Row, fields: FieldMap,
-                  offset: int = 0) -> tuple[Key | None, int | None]:
+    def _read_row(
+        self, row: Row, fields: FieldMap, offset: int = 0
+    ) -> tuple[Key | None, int | None, list[Key]]:
         pos_field = fields.get("pos", "position")
         if pos_field in row and row[pos_field] == "":
             # Date/time row, track last_time
             self._last_time = str(row[fields["title"]])
-            return None, None
+            return None, None, []
         if pos_field not in row and str(int(self._year)) in row:
             row[pos_field] = row[str(int(self._year))]
 

--- a/top2000/readers/multi.py
+++ b/top2000/readers/multi.py
@@ -3,11 +3,13 @@ Multiple file reader.
 """
 
 from pathlib import Path
-from .base import Base, Row
+
+from .base import Artists, Base, Positions, Row
 from .csv import CSV
 from .json import JSON
 
 OldFiles = tuple[tuple[float, str, str], ...]
+
 
 @Base.register("multi")
 class Years(Base):
@@ -16,13 +18,29 @@ class Years(Base):
     different years in order to obtain track metadata and positions.
     """
 
+    has_multiple_years = True
+
     @property
     def input_format(self) -> str | None:
         return None
 
-    def format_filenames(self, csv_name_format: str | None = None,
-                         json_name_format: str | None = None, *,
-                         year: float | None = None) -> tuple[str, str]:
+    def reset(self) -> None:
+        super().reset()
+        self._year_positions: dict[float, Positions] = {}
+        self._year_artists: dict[float, Artists] = {}
+        self.reset_year()
+
+    def reset_year(self) -> None:
+        self._positions = self._year_positions.setdefault(self._year, {})
+        self._artists = self._year_artists.setdefault(self._year, {})
+
+    def format_filenames(
+        self,
+        csv_name_format: str | None = None,
+        json_name_format: str | None = None,
+        *,
+        year: float | None = None,
+    ) -> tuple[str, str]:
         """
         Format CSV and JSON filenames for a particular year.
         """
@@ -31,15 +49,17 @@ class Years(Base):
             year = self._year
 
         if csv_name_format is None:
-            csv_name_format = self._fields.get_str_field(year, "csv", "name",
-                                                         self.csv_name_format)
-        csv_name = csv_name_format.format(year)
+            csv_name_format = self._fields.get_str_field(
+                year, "csv", "name", self.csv_name_format
+            )
+        csv_name = csv_name_format.format(int(year))
 
         if json_name_format is None:
-            json_name_format = self._fields.get_str_field(year, "json", "name",
-                                                          self.json_name_format)
+            json_name_format = self._fields.get_str_field(
+                year, "json", "name", self.json_name_format
+            )
 
-        json_name = json_name_format.format(year)
+        json_name = json_name_format.format(int(year))
 
         return csv_name, json_name
 
@@ -47,9 +67,12 @@ class Years(Base):
         csv_name, json_name = self.format_filenames()
         self.read_files(csv_name, json_name)
 
-    def read_files(self, current_year_csv: str | None = None,
-                   current_year_json: str | None = None,
-                   old: OldFiles | None = None) -> None:
+    def read_files(
+        self,
+        current_year_csv: str | None = None,
+        current_year_json: str | None = None,
+        old: OldFiles | None = None,
+    ) -> None:
         """
         Read JSON and/or CSV files for the current year as well as older years.
         """
@@ -59,14 +82,21 @@ class Years(Base):
         # Read current year
         if current_year_json is not None and current_year_json != "":
             json = JSON(self._year, fields=self._fields)
-            json.read_file(Path(current_year_json), tracks=self._tracks,
-                           artists=self._artists)
-            self._positions = json.positions
+            json.read_file(
+                Path(current_year_json), tracks=self._tracks, artists=self._artists
+            )
+            self._positions = self._year_positions[self._year] = json.positions
+            self._artists = self._year_artists[self._year] = json.artists
         if current_year_csv is not None and current_year_csv != "":
             csv = CSV(self._year, fields=self._fields)
-            csv.read_file(Path(current_year_csv), positions=self._positions,
-                          tracks=self._tracks, artists=self._artists)
-            self._positions = csv.positions
+            csv.read_file(
+                Path(current_year_csv),
+                positions=self._positions,
+                tracks=self._tracks,
+                artists=self._artists,
+            )
+            self._positions = self._year_positions[self._year] = csv.positions
+            self._artists = self._year_artists[self._year] = csv.artists
 
         if old is not None:
             self._read_old_files(old)
@@ -77,7 +107,7 @@ class Years(Base):
         in them.
         """
 
-        for (year, overview_csv_name, overview_json_name) in old:
+        for year, overview_csv_name, overview_json_name in old:
             overview_json_path = Path(overview_json_name)
             skip_json = self._fields.get_bool_field(year, "json", "skip")
             if overview_json_path.exists() and not skip_json:
@@ -86,14 +116,17 @@ class Years(Base):
                     json.read_old_file(overview_json_path, tracks=self._tracks)
                 else:
                     json.read_file(overview_json_path, tracks=self._tracks)
+                self._year_positions[year] = json.positions
+                self._year_artists[year] = json.artists
             else:
                 # No JSON file, so instead use CSV (very old years)
                 # These are overview CSV files with possibly multiple years
                 # The current year position is stored in a "pos XXXX" field
-                self._fields.update_year(year,
-                                         {"csv": {"pos": f"pos {int(year)}"}})
+                self._fields.update_year(year, {"csv": {"pos": f"pos {int(year)}"}})
                 csv = CSV(year, is_current_year=False, fields=self._fields)
                 csv.read_file(Path(overview_csv_name), tracks=self._tracks)
+                self._year_positions[year] = csv.positions
+                self._year_artists[year] = csv.artists
 
     @property
     def credits(self) -> Row:
@@ -101,5 +134,5 @@ class Years(Base):
             "name": "NPO Radio 2 Top 2000",
             "publisher": "NPO",
             "url": "https://www.nporadio2.nl/top2000",
-            "terms": "https://npo.nl/overnpo/algemene-voorwaarden/algemene-voorwaarden-online"
+            "terms": "https://npo.nl/overnpo/algemene-voorwaarden/algemene-voorwaarden-online",
         }


### PR DESCRIPTION
This improves performance for readers that already provide all the data of the years, provided we do our bookkeeping right.

- Provide artist and title yet for old tracks no longer in current track
- Correct CSV/multi-year reading
- Correct zero position for old CSV reader
- Avoid duplicating or moving primary reader in multi-year main loop from output
- Format year position fields after current year as integer