### PR TITLE
Avoid issues with recompile loops in dev mode

### DIFF
--- a/srv/tabs/index.js
+++ b/srv/tabs/index.js
@@ -106,7 +106,7 @@ export default class Tabs {
                     else {
                         import(
                             /* webpackInclude: /output-\d\d\d\d\.json$/ */
-                            `../../output-${d}.json`
+                            `@output/output-${d}.json`
                         ).then(data => {
                             load(new Data(data)).enable(load);
                             this.scroll.scrollYearHash(d, hash);

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -81,7 +81,7 @@ module.exports = {
         }
     },
     output: {
-        clean: true,
+        clean: process.env.NODE_ENV !== 'development',
         filename: '[name].[contenthash].js',
         path: path.resolve(__dirname, 'dist'),
         publicPath: ""
@@ -117,7 +117,12 @@ module.exports = {
                 !file.name.startsWith("schema/")
         })
     ],
+    resolve: {
+        alias: {
+            "@output": path.resolve(__dirname)
+        }
+    },
     watchOptions: {
-        ignored: ['.git', 'dist', 'node_modules', 'top2000']
+        ignored: ['**/.git', '**/dist', '**/node_modules', '**/top2000']
     }
 };


### PR DESCRIPTION
- Use alias instead of relative path for loading output dumps of earlier year charts
- Do not try to clean dist directory in development
- Adjust watch ignore paths to include prefix glob so they match when absolute paths are used by webpack. This avoids recompile from changes to cache in `node_modules` or other ignored paths.