### PR TITLE
Older year chart progression

### DIFF
--- a/srv/data.js
+++ b/srv/data.js
@@ -1,3 +1,5 @@
+export const EXPECTED_POSITIONS = 2000;
+
 export default class Data {
     constructor(data, locale) {
         Object.assign(this, data);
@@ -8,6 +10,9 @@ export default class Data {
 
         this.trackColumns = ["position", "artist", "title"];
         this.artistColumns = ["position", "title", "year"];
+        if (data.latest_year && data.year !== data.latest_year) {
+            this.trackColumns.push("current");
+        }
         if (this.tracks[0].timestamp) {
             this.trackColumns.push("timestamp");
             this.artistColumns.push("timestamp");
@@ -29,9 +34,20 @@ export default class Data {
                 column: data.columns.year,
                 field: d => d.year
             },
+            current: {
+                column: data.latest_year,
+                field: d => d[data.latest_year] || "\u2014"
+            },
             timestamp: {
                 column: data.columns.timestamp,
-                field: d => d.timestamp ? locale.formatTime(new Date(d.timestamp)) : ""
+                field: d => {
+                    if (!d.timestamp) {
+                        return "";
+                    }
+                    return !data.latest_year || data.year === data.latest_year ?
+                        locale.formatTimeShort(new Date(d.timestamp)) :
+                        locale.formatTimeLong(new Date(d.timestamp));
+                }
             }
         };
     }
@@ -63,7 +79,7 @@ export default class Data {
 
     formatArtistChart(d, position, keys) {
         const artistTracks = this.artists[d.max_artist_key] ?
-            this.artists[d.max_artist_key] : this.artists[keys[0][0]];
+            this.artists[d.max_artist_key] : this.artists[keys[0]?.[0]];
         if (artistTracks) {
             const artistPos = artistTracks.indexOf(position) + 1;
             return ` ${artistPos}/${artistTracks.length}`;

--- a/srv/locale.js
+++ b/srv/locale.js
@@ -12,7 +12,8 @@ export default class Locale {
             months: ["Januari", "Februari", "Maart", "April", "Mei", "Juni", "Juli", "Augustus", "September", "Oktober", "November", "December"],
             shortMonths: ["jan", "feb", "mrt", "apr", "mei", "jun", "jul", "aug", "sep", "okt", "nov", "dec"]
         });
-        this.formatTime = this.time.format("%d-%m %H:%M");
+        this.formatTimeShort = this.time.format("%d-%m %H:%M");
+        this.formatTimeLong = this.time.format("%d-%m-'%y %H:%M");
         this.formatYear = this.time.format("'%y");
         this.formatTimerLong = this.time.utcFormat("%-j:%H:%M:%S");
         this.formatTimerShort = this.time.utcFormat("%H:%M:%S");

--- a/srv/scroll.js
+++ b/srv/scroll.js
@@ -1,8 +1,10 @@
 import * as d3 from "d3";
+import { EXPECTED_POSITIONS } from "./data.js";
 
 const rowsSelector = "table.main > tbody > tr:not(.info)";
 const currentDisplayDelay = 10000;
 const currentUpdateDelay = 1000;
+const pagesCount = 20;
 
 export default class Scroll {
     constructor(locale, data, format, state) {
@@ -78,7 +80,7 @@ export default class Scroll {
     scrollPositionRow(d) {
         const data = this.data;
         const posCell = this.container.selectAll(`${rowsSelector} > td:first-child`)
-            .select(function (pos) {
+            .select(function(pos) {
                 return d === data.positions[pos] ? this : null;
             })
             .node();
@@ -98,7 +100,7 @@ export default class Scroll {
     }
 
     updatePagination(current = null) {
-        const count = Math.min(Math.max(this.data.end, this.data.front), 20)
+        const count = Math.min(Math.max(this.data.end, this.data.front), pagesCount);
         const pages = d3.ticks(...d3.nice(this.data.end, this.data.front, count), count);
         if (current) {
             const currentIndex = this.data.reverse ? d3.bisectLeft(pages, current) :
@@ -138,6 +140,9 @@ export default class Scroll {
             )
             .classed("is-hidden-touch",
                 (d, i) => i !== 0 && d !== current && d % 500 !== 0
+            )
+            .classed("is-hidden-fullhd",
+                (d, i) => pages.length > pagesCount && i !== 0 && d !== current && d > EXPECTED_POSITIONS && d % 500 !== 0
             )
             .text(d => d);
     }

--- a/srv/style.scss
+++ b/srv/style.scss
@@ -159,6 +159,9 @@ table.main {
         }
         .progression {
             overflow: auto;
+            .x-extra, .y-current-year {
+              stroke-dasharray: 4;
+            }
         }
         .container.artist-chart {
             max-width: fit-content;

--- a/srv/tabs/charts.js
+++ b/srv/tabs/charts.js
@@ -1,6 +1,6 @@
 import * as d3 from "d3";
+import { EXPECTED_POSITIONS } from "../data.js";
 
-const EXPECTED_POSITIONS = 2000;
 const CHART_COUNT = 10;
 const stroke = d3.scaleOrdinal(d3.schemeTableau10);
 const cycle = stroke.range().length;

--- a/srv/tabs/table.js
+++ b/srv/tabs/table.js
@@ -18,11 +18,16 @@ export default class Table {
         table.append("thead")
             .append("tr")
             .selectAll("th")
-            .data([...this.data.trackColumns, ""])
+            .data([...this.data.trackColumns, "search"])
             .join("th")
             .each((d, i, nodes) => {
                 const cell = d3.select(nodes[i]);
-                if (i === this.data.trackColumns.length) {
+                if (d === "current") {
+                    cell.append("a")
+                        .attr("href", `#/${this.data.latest_year}`)
+                        .text(this.data.latest_year);
+                }
+                else if (d === "search") {
                     cell.append("a")
                         .on("click", () => this.search.open())
                         .text(String.fromCodePoint(0x1f50e));


### PR DESCRIPTION
Closes #44

- Display later years in chart
- Display extra lines in chart for current year and position 2000 in case the year has more than 2000 positions
- Display what the current year position is in older year charts as indication on how it fares right now, with link to current year
- Display more complete timestamp with year for older year charts
- Avoid too many pagination links for year with more than 2000 positions causing extra line on full HD screens
- Handle potentially missing fields for older year charts, for example links for De Extra 500 and keys for some collided tracks