### PR TITLE
Avoid scroll when activating/leaving modal dialog with tab/hash

### DIFF
--- a/srv/scroll.js
+++ b/srv/scroll.js
@@ -78,6 +78,9 @@ export default class Scroll {
     }
 
     scrollPositionRow(d) {
+        if (d === null && this.state.autoscroll) {
+            d = this.nextPage.datum();
+        }
         const data = this.data;
         const posCell = this.container.selectAll(`${rowsSelector} > td:first-child`)
             .select(function(pos) {
@@ -95,7 +98,7 @@ export default class Scroll {
 
     scrollYearHash(d, hash) {
         this.scrollPositionRow(Number(hash.startsWith(`#/${d}/`) ?
-            hash.slice(`#/${d}/`.length) : this.nextPage.datum()
+            hash.slice(`#/${d}/`.length) : null
         ));
     }
 

--- a/srv/tabs/table.js
+++ b/srv/tabs/table.js
@@ -29,7 +29,7 @@ export default class Table {
                 }
                 else if (d === "search") {
                     cell.append("a")
-                        .on("click", () => this.search.open())
+                        .attr("href", `#/search/${this.data.year}`)
                         .text(String.fromCodePoint(0x1f50e));
                 }
                 else {


### PR DESCRIPTION
Closes #49 

- The background container now remains where it was when the modal is opened or closed
- Avoid autoscroll to trigger when returning to year chart from modal if it is not enabled
- Include year in hash for modals
- Correct hash of chart and info pages when switching between tabs
- Change table header search icon to use hash with current year