### PR TITLE
Improve scroll behavior after closing modal and on Firefox on Android

### DIFF
--- a/doc/app.nl.md
+++ b/doc/app.nl.md
@@ -15,6 +15,8 @@ symbolen betekenen en welke interacties beschikbaar zijn.
 | &#x2139;&#xfe0f; | Tabs | Informatie met gebruiksinstructies en credits |
 | &#x1f50e; | Tabs, tabel | [Zoekveld](#zoekveld) openen |
 | &#x1f4e4; | Tabs        | [Uploaden](#uploaden)        |
+| &#x2600;&#xfe0f; | Tabs | Licht thema gebruiken        |
+| &#x1f319; | Tabs        | Donker thema gebruiken       |
 | &#x29be;  | Titel       | Albumversie                  |
 | &#x25b2;  | Titel       | Aantal plaatsen gestegen     |
 | &#x25bc;  | Titel       | Aantal plaatsen gedaald      |

--- a/srv/modal/search.js
+++ b/srv/modal/search.js
@@ -57,6 +57,11 @@ export default class SearchModal extends Modal {
             fuzzy: 0.2,
             prefix: true
         }, (r) => {
+            this.state.autoscroll = false;
+            globalThis.history.pushState({ modalClosed: "search" }, "",
+                `#/${this.data.year}/${this.data.positions[r.id]}`
+            );
+            this.close();
             const posNode = this.scroll.scrollPositionRow(this.data.positions[r.id]);
             if (posNode) {
                 // Expand info
@@ -70,10 +75,7 @@ export default class SearchModal extends Modal {
                     },
                     posNode, null, false
                 );
-                this.state.autoscroll = false;
-                modal.classed("is-active", false);
             }
-            document.location.hash = `#/${this.data.year}/${this.data.positions[r.id]}`;
         });
         input.on("keydown", (event) => {
             if (event.key === "Escape") {

--- a/srv/scroll.js
+++ b/srv/scroll.js
@@ -40,9 +40,6 @@ export default class Scroll {
         this.nextPage = this.nav.append("a")
             .attr("id", "pagination-next")
             .classed("pagination-next is-hidden", true);
-        this.nextPage.on("click", (_, d) => {
-            this.scrollPage(d, d);
-        });
 
         this.input = this.nav.append("input")
             .attr("id", "pagination-input")
@@ -78,9 +75,13 @@ export default class Scroll {
         });
     }
 
-    scrollPage(d, current = null) {
+    scrollPage(d) {
         const posNode = this.scrollPositionRow(d);
         if (posNode) {
+            const current = this.nextPage.datum();
+            if (d === null) {
+                d = current;
+            }
             this.pagination.selectAll(".pagination-link")
                 .classed("is-current", pos => d === pos);
             this.container.selectAll(rowsSelector)
@@ -104,7 +105,7 @@ export default class Scroll {
             .node();
         if (posCell) {
             posCell.scrollIntoView({
-                behavior: "smooth", block: "center"
+                behavior: "smooth", block: "center", container: "nearest"
             });
             return posCell.parentNode;
         }
@@ -112,7 +113,7 @@ export default class Scroll {
     }
 
     scrollYearHash(d, hash) {
-        this.scrollPositionRow(hash.startsWith(`#/${d}/`) ?
+        this.scrollPage(hash.startsWith(`#/${d}/`) ?
             Number(hash.slice(`#/${d}/`.length)) : null
         );
     }
@@ -156,9 +157,6 @@ export default class Scroll {
                 exit => exit.remove()
             )
             .attr("href", d => `#/${this.data.year}/${d}`)
-            .on("click", (_, d) => {
-                this.scrollPage(d, current);
-            })
             .classed("has-background-primary has-text-dark", d => d === current)
             .classed("is-hidden-desktop-only",
                 (d, i) => i !== 0 && d !== current && d % 200 !== 0


### PR DESCRIPTION
Closes #58 

- Avoid setting hash directly and instead push state
- Use state to detect if the modal has been closed with a new hash and thus fewer changes need to be made to update the active tab to avoid duplicate/out-of-order scroll attempts on the container
- Avoid more duplicate scrolls where the consecutive scroll is not instantaneous as the new animation cancels the previous scroll
- Replace click handlers on pagination with hash usage and current track detection preservation
- Correct theme active content update breakage
- Add theme toggle symbol explanation to docs